### PR TITLE
Add sphinx extension for quantization docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinxcontrib.katex',
+    'sphinx.ext.autosectionlabel',
 ]
 
 # katex options


### PR DESCRIPTION
Add sphinx.ext.autosectionlabel so that we can reference the quantization docs by the title

